### PR TITLE
Feat/block txs request improvments

### DIFF
--- a/yarn-project/p2p/src/client/test/p2p_client.integration_block_txs.test.ts
+++ b/yarn-project/p2p/src/client/test/p2p_client.integration_block_txs.test.ts
@@ -6,8 +6,9 @@ import { type Logger, createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 import { emptyChainConfig } from '@aztec/stdlib/config';
 import type { WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
+import { BlockProposal } from '@aztec/stdlib/p2p';
 import { makeBlockProposal, makeHeader, mockTx } from '@aztec/stdlib/testing';
-import { Tx, TxHash } from '@aztec/stdlib/tx';
+import { Tx, TxHash, TxHashArray } from '@aztec/stdlib/tx';
 
 import { describe, expect, it, jest } from '@jest/globals';
 import { type MockProxy, mock } from 'jest-mock-extended';
@@ -40,8 +41,9 @@ describe('p2p client integration block txs protocol ', () => {
 
   const blockNumber = 5;
   const blockHash = Fr.random();
-  let txs: any[];
-  let txHashes: any[];
+  let txs: Tx[];
+  let txHashes: TxHash[];
+  let blockProposal: BlockProposal;
 
   beforeEach(async () => {
     txPool = mock<TxPool>();
@@ -94,7 +96,7 @@ describe('p2p client integration block txs protocol ', () => {
 
     txs = await Promise.all(times(5, () => mockTx()));
     txHashes = await Promise.all(txs.map(tx => tx.getTxHash()));
-    const blockProposal = createBlockProposal(blockNumber, blockHash, txHashes);
+    blockProposal = createBlockProposal(blockNumber, blockHash, txHashes);
     attestationPool.getBlockProposal.mockResolvedValue(blockProposal);
   });
 
@@ -125,10 +127,9 @@ describe('p2p client integration block txs protocol ', () => {
     });
   };
 
-  const sendBlockTxsRequest = (blockHash: Fr, requestedIndices: number[], txCount: number) => {
+  const sendBlockTxsRequest = (blockProposal: BlockProposal, missingHashes: TxHash[]) => {
     const [client1, client2] = clients as any;
-    const txIndices = BitVector.init(txCount, requestedIndices);
-    const request = new BlockTxsRequest(blockHash, txIndices);
+    const request = BlockTxsRequest.fromBlockProposalAndMissingTxs(blockProposal, missingHashes)!;
     return client1.p2pService.reqresp.sendRequestToPeer(
       client2.p2pService.node.peerId,
       ReqRespSubProtocol.BLOCK_TXS,
@@ -138,8 +139,10 @@ describe('p2p client integration block txs protocol ', () => {
 
   it('responds with NOT_FOUND when peer does not have the requested block proposal', async () => {
     attestationPool.getBlockProposal.mockResolvedValue(undefined);
+    const missing = new TxHashArray(...Array.from({ length: 4 }, () => TxHash.random()));
 
-    const response = await sendBlockTxsRequest(Fr.random(), [0, 2, 5], 10);
+    const blockProposal = createBlockProposal(blockNumber, Fr.random(), missing);
+    const response = await sendBlockTxsRequest(blockProposal, missing);
 
     expect(response.status).toBe(ReqRespStatus.NOT_FOUND);
   });
@@ -156,7 +159,11 @@ describe('p2p client integration block txs protocol ', () => {
     });
 
     const requestedIndices = [0, 2, 4];
-    const response = await sendBlockTxsRequest(blockHash, requestedIndices, txs.length);
+    const response = await sendBlockTxsRequest(
+      blockProposal,
+      txHashes.filter((_, i) => requestedIndices.includes(i)),
+    );
+    //const response = await sendBlockTxsRequest(blockHash, requestedIndices, txs.length);
 
     expect(response.status).toBe(ReqRespStatus.SUCCESS);
     const blockTxsResponse = BlockTxsResponse.fromBuffer(response.data);
@@ -189,7 +196,10 @@ describe('p2p client integration block txs protocol ', () => {
     });
 
     const requestedIndices = [0, 1, 2, 4];
-    const response = await sendBlockTxsRequest(blockHash, requestedIndices, txs.length);
+    const response = await sendBlockTxsRequest(
+      blockProposal,
+      txHashes.filter((_, i) => requestedIndices.includes(i)),
+    );
 
     expect(response.status).toBe(ReqRespStatus.SUCCESS);
     const blockTxsResponse = BlockTxsResponse.fromBuffer(response.data);
@@ -210,7 +220,10 @@ describe('p2p client integration block txs protocol ', () => {
     });
 
     const requestedIndices = [0, 2, 4];
-    const response = await sendBlockTxsRequest(blockHash, requestedIndices, txs.length);
+    const response = await sendBlockTxsRequest(
+      blockProposal,
+      txHashes.filter((_, i) => requestedIndices.includes(i)),
+    );
 
     expect(response.status).toBe(ReqRespStatus.SUCCESS);
     const blockTxsResponse = BlockTxsResponse.fromBuffer(response.data);

--- a/yarn-project/p2p/src/client/test/p2p_client.integration_block_txs.test.ts
+++ b/yarn-project/p2p/src/client/test/p2p_client.integration_block_txs.test.ts
@@ -18,7 +18,6 @@ import { type P2PConfig, getP2PDefaultConfig } from '../../config.js';
 import type { AttestationPool } from '../../mem_pools/attestation_pool/attestation_pool.js';
 import type { TxPool } from '../../mem_pools/tx_pool/index.js';
 import { ReqRespSubProtocol } from '../../services/reqresp/interface.js';
-import { BitVector } from '../../services/reqresp/protocols/block_txs/bitvector.js';
 import { BlockTxsRequest, BlockTxsResponse } from '../../services/reqresp/protocols/block_txs/block_txs_reqresp.js';
 import { ReqRespStatus } from '../../services/reqresp/status.js';
 import { makeAndStartTestP2PClients } from '../../test-helpers/make-test-p2p-clients.js';
@@ -127,9 +126,13 @@ describe('p2p client integration block txs protocol ', () => {
     });
   };
 
-  const sendBlockTxsRequest = (blockProposal: BlockProposal, missingHashes: TxHash[]) => {
+  const sendBlockTxsRequest = (blockProposal: BlockProposal, missingHashes: TxHash[], includeFullTxHashes = false) => {
     const [client1, client2] = clients as any;
-    const request = BlockTxsRequest.fromBlockProposalAndMissingTxs(blockProposal, missingHashes)!;
+    const request = BlockTxsRequest.fromBlockProposalAndMissingTxs(blockProposal, missingHashes, includeFullTxHashes);
+    if (!request) {
+      return undefined;
+    }
+
     return client1.p2pService.reqresp.sendRequestToPeer(
       client2.p2pService.node.peerId,
       ReqRespSubProtocol.BLOCK_TXS,
@@ -230,5 +233,177 @@ describe('p2p client integration block txs protocol ', () => {
     expect(blockTxsResponse.blockHash.equals(blockHash)).toBe(true);
     expect(blockTxsResponse.txs.length).toBe(0);
     expect(blockTxsResponse.txIndices.getTrueIndices()).toEqual([]);
+  });
+
+  it('responds with all requested txs when using includeFullTxHashes=true', async () => {
+    const hashToTx = new Map(txs.map((tx, i) => [txHashes[i].toString(), tx]));
+    txPool.getTxsByHash.mockImplementation((hashes: TxHash[]) =>
+      Promise.resolve(hashes.map(h => hashToTx.get(h.toString())!)),
+    );
+
+    txPool.hasTxs.mockImplementation((hashes: TxHash[]) => {
+      const txsInPool = new Set(hashToTx.keys());
+      return Promise.resolve(hashes.map(h => txsInPool.has(h.toString())));
+    });
+
+    const requestedIndices = [1, 3, 4];
+    const response = await sendBlockTxsRequest(
+      blockProposal,
+      txHashes.filter((_, i) => requestedIndices.includes(i)),
+      true, // includeFullTxHashes=true
+    );
+
+    expect(response.status).toBe(ReqRespStatus.SUCCESS);
+    const blockTxsResponse = BlockTxsResponse.fromBuffer(response.data);
+    expect(blockTxsResponse.blockHash.equals(blockHash)).toBe(true);
+    expect(blockTxsResponse.txs.length).toBe(requestedIndices.length);
+    expect(blockTxsResponse.txIndices.getTrueIndices()).toEqual([0, 1, 2, 3, 4]);
+
+    const expectedHashes = requestedIndices.map(index => txHashes[index]);
+    const actualHashes = await Promise.all(blockTxsResponse.txs.map(tx => tx.getTxHash()));
+    expect(actualHashes).toEqual(expectedHashes);
+  });
+
+  it('responds with partial txs when peer has some and request uses full hashes', async () => {
+    const availableIndices = new Set([1, 3]); // Only have txs at indices 1 and 3
+    const hashToTx: Map<string, Tx> = new Map(
+      txs.map((tx, i) => [txHashes[i].toString(), tx] as [string, Tx]).filter((_, i) => availableIndices.has(i)),
+    );
+
+    txPool.getTxsByHash.mockImplementation((hashes: TxHash[]) => {
+      return Promise.resolve(
+        hashes.map(hash => {
+          return hashToTx.get(hash.toString());
+        }),
+      );
+    });
+
+    txPool.hasTxs.mockImplementation((hashes: TxHash[]) => {
+      const txsInPool = new Set(hashToTx.keys());
+      return Promise.resolve(hashes.map(h => txsInPool.has(h.toString())));
+    });
+
+    const requestedIndices = [0, 1, 3, 4]; // Request 4 txs but only 2 are available
+    const response = await sendBlockTxsRequest(
+      blockProposal,
+      txHashes.filter((_, i) => requestedIndices.includes(i)),
+      true, // includeFullTxHashes=true
+    );
+
+    expect(response.status).toBe(ReqRespStatus.SUCCESS);
+    const blockTxsResponse = BlockTxsResponse.fromBuffer(response.data);
+    expect(blockTxsResponse.blockHash.equals(blockHash)).toBe(true);
+    expect(blockTxsResponse.txs.length).toBe(2); // Only 2 txs returned
+    expect(blockTxsResponse.txIndices.getTrueIndices()).toEqual([1, 3]); // Only indices 1 and 3 available
+
+    const expectedHashes = [1, 3].map(index => txHashes[index]);
+    const actualHashes = await Promise.all(blockTxsResponse.txs.map(tx => tx.getTxHash()));
+    expect(actualHashes).toEqual(expectedHashes);
+  });
+
+  it('handles empty request when using includeFullTxHashes=true', async () => {
+    txPool.getTxsByHash.mockResolvedValue([]);
+    txPool.hasTxs.mockImplementation((hashes: TxHash[]) => {
+      return Promise.resolve(hashes.map(_ => false));
+    });
+
+    const response = await sendBlockTxsRequest(blockProposal, [], true);
+
+    expect(response).not.toBeDefined();
+  });
+
+  it('responds with txs when peer does not have proposal but has txs (includeFullTxHashes=true)', async () => {
+    // Peer doesn't have the block proposal
+    attestationPool.getBlockProposal.mockResolvedValue(undefined);
+
+    // But peer has some of the requested txs in their pool
+    const availableTxs = [txs[1], txs[3]];
+    const availableHashes = [txHashes[1], txHashes[3]];
+    const hashToTx = new Map(availableTxs.map((tx, i) => [availableHashes[i].toString(), tx]));
+
+    txPool.getTxsByHash.mockImplementation((hashes: TxHash[]) => {
+      return Promise.resolve(hashes.map(hash => hashToTx.get(hash.toString())).filter(tx => tx !== undefined));
+    });
+
+    const requestedHashes = [txHashes[1], txHashes[3], txHashes[4]]; // Request 3, but only 2 available
+    const differentBlockProposal = createBlockProposal(blockNumber, Fr.random(), txHashes);
+    const response = await sendBlockTxsRequest(differentBlockProposal, requestedHashes, true);
+
+    expect(response.status).toBe(ReqRespStatus.SUCCESS);
+    const blockTxsResponse = BlockTxsResponse.fromBuffer(response.data);
+
+    // When peer doesn't have proposal but has txs, it returns Fr.ZERO as blockHash
+    expect(blockTxsResponse.blockHash.equals(Fr.ZERO)).toBe(true);
+    expect(blockTxsResponse.txs.length).toBe(2); // Only 2 txs available
+    expect(blockTxsResponse.txIndices.getLength()).toBe(0); // Empty BitVector when no proposal
+
+    const actualHashes = await Promise.all(blockTxsResponse.txs.map(tx => tx.getTxHash()));
+    expect(actualHashes).toEqual([txHashes[1], txHashes[3]]);
+  });
+
+  it('responds with partial txs when peer does not have proposal (includeFullTxHashes=true)', async () => {
+    // Peer doesn't have the block proposal
+    attestationPool.getBlockProposal.mockResolvedValue(undefined);
+
+    // Peer has only one of the requested txs
+    const availableTx = txs[2];
+    const availableHash = txHashes[2];
+
+    txPool.getTxsByHash.mockImplementation((hashes: TxHash[]) => {
+      return Promise.resolve(
+        hashes.map(hash => (hash.equals(availableHash) ? availableTx : undefined)).filter(tx => tx !== undefined),
+      );
+    });
+
+    const requestedHashes = [txHashes[0], txHashes[2], txHashes[4]]; // Request 3, only 1 available
+    const differentBlockProposal = createBlockProposal(blockNumber, Fr.random(), txHashes);
+    const response = await sendBlockTxsRequest(differentBlockProposal, requestedHashes, true);
+
+    expect(response.status).toBe(ReqRespStatus.SUCCESS);
+    const blockTxsResponse = BlockTxsResponse.fromBuffer(response.data);
+
+    expect(blockTxsResponse.blockHash.equals(Fr.ZERO)).toBe(true);
+    expect(blockTxsResponse.txs.length).toBe(1); // Only 1 tx available
+    expect(blockTxsResponse.txIndices.getLength()).toBe(0);
+
+    const actualHashes = await Promise.all(blockTxsResponse.txs.map(tx => tx.getTxHash()));
+    expect(actualHashes).toEqual([txHashes[2]]);
+  });
+
+  it('responds with empty txs when peer does not have proposal or txs (includeFullTxHashes=true)', async () => {
+    // Peer doesn't have the block proposal
+    attestationPool.getBlockProposal.mockResolvedValue(undefined);
+
+    // Peer also doesn't have any of the requested txs
+    txPool.getTxsByHash.mockResolvedValue([]);
+
+    const requestedHashes = [txHashes[0], txHashes[2], txHashes[4]];
+    const differentBlockProposal = createBlockProposal(blockNumber, Fr.random(), txHashes);
+    const response = await sendBlockTxsRequest(differentBlockProposal, requestedHashes, true);
+
+    expect(response.status).toBe(ReqRespStatus.SUCCESS);
+    const blockTxsResponse = BlockTxsResponse.fromBuffer(response.data);
+
+    expect(blockTxsResponse.blockHash.equals(Fr.ZERO)).toBe(true);
+    expect(blockTxsResponse.txs.length).toBe(0); // No txs available
+    expect(blockTxsResponse.txIndices.getLength()).toBe(0);
+  });
+
+  it('still responds with NOT_FOUND when peer does not have proposal and includeFullTxHashes=false', async () => {
+    // Peer doesn't have the block proposal
+    attestationPool.getBlockProposal.mockResolvedValue(undefined);
+
+    // Even if peer has the txs in pool
+    const hashToTx = new Map(txs.map((tx, i) => [txHashes[i].toString(), tx]));
+    txPool.getTxsByHash.mockImplementation((hashes: TxHash[]) =>
+      Promise.resolve(hashes.map(h => hashToTx.get(h.toString())!)),
+    );
+
+    const requestedHashes = [txHashes[1], txHashes[3]];
+    const differentBlockProposal = createBlockProposal(blockNumber, Fr.random(), txHashes);
+    const response = await sendBlockTxsRequest(differentBlockProposal, requestedHashes, false); // includeFullTxHashes=false
+
+    // Should get NOT_FOUND because without full tx hashes, handler can't return txs without proposal
+    expect(response.status).toBe(ReqRespStatus.NOT_FOUND);
   });
 });

--- a/yarn-project/p2p/src/services/reqresp/batch-tx-requester/batch_tx_requester.ts
+++ b/yarn-project/p2p/src/services/reqresp/batch-tx-requester/batch_tx_requester.ts
@@ -228,7 +228,15 @@ export class BatchTxRequester {
       }
 
       const txs = chunks[idx].map(t => TxHash.fromString(t));
-      const blockRequest = BlockTxsRequest.fromBlockProposalAndMissingTxs(this.blockProposal, txs);
+
+      // If peer is dumb peer, we don't know yet if they received full blockProposal
+      // there is solid chance that peer didn't receive proposal yet, thus we must send full hashes
+      const includeFullHashesInRequestNotJustIndices = true;
+      const blockRequest = BlockTxsRequest.fromBlockProposalAndMissingTxs(
+        this.blockProposal,
+        txs,
+        includeFullHashesInRequestNotJustIndices,
+      );
       if (!blockRequest) {
         return undefined;
       }
@@ -545,6 +553,9 @@ export class BatchTxRequester {
       return;
     }
 
+    // If block response is invalid we still want to query this peer in the future
+    // Because they sent successful response, so they might become smart peer in the future
+    // Or send us needed txs
     if (!this.isBlockResponseValid(response)) {
       return;
     }

--- a/yarn-project/p2p/src/services/reqresp/protocols/block_txs/block_txs.test.ts
+++ b/yarn-project/p2p/src/services/reqresp/protocols/block_txs/block_txs.test.ts
@@ -1,6 +1,6 @@
 import { Fr } from '@aztec/foundation/fields';
 import { mockTx } from '@aztec/stdlib/testing';
-import { TxArray } from '@aztec/stdlib/tx';
+import { TxArray, TxHash, TxHashArray } from '@aztec/stdlib/tx';
 
 import { describe, expect, it } from '@jest/globals';
 
@@ -10,13 +10,16 @@ import { BlockTxsRequest, BlockTxsResponse } from './block_txs_reqresp.js';
 describe('BlockTxRequest', () => {
   it('should serialize and deserialize correctly', () => {
     const blockHash = Fr.random();
+    const missing = new TxHashArray(...Array.from({ length: 4 }, () => TxHash.random()));
     const txIndices = BitVector.init(16, [0, 5, 10, 15]);
 
-    const original = new BlockTxsRequest(blockHash, txIndices);
+    const original = new BlockTxsRequest(blockHash, missing, txIndices);
     const buffer = original.toBuffer();
     const deserialized = BlockTxsRequest.fromBuffer(buffer);
 
     expect(deserialized.blockHash).toEqual(original.blockHash);
+    expect(deserialized.txHashes.length).toBe(original.txHashes.length);
+    expect(deserialized.txHashes).toEqual(original.txHashes);
     expect(deserialized.txIndices.getLength()).toBe(original.txIndices.getLength());
     expect(deserialized.txIndices.getTrueIndices()).toEqual(original.txIndices.getTrueIndices());
   });
@@ -25,7 +28,7 @@ describe('BlockTxRequest', () => {
     const blockHash = Fr.random();
     const txIndices = BitVector.init(8, []);
 
-    const original = new BlockTxsRequest(blockHash, txIndices);
+    const original = new BlockTxsRequest(blockHash, new TxHashArray(), txIndices);
     const buffer = original.toBuffer();
     const deserialized = BlockTxsRequest.fromBuffer(buffer);
 

--- a/yarn-project/p2p/src/services/reqresp/protocols/block_txs/block_txs.test.ts
+++ b/yarn-project/p2p/src/services/reqresp/protocols/block_txs/block_txs.test.ts
@@ -1,5 +1,7 @@
+import { Secp256k1Signer } from '@aztec/foundation/crypto';
 import { Fr } from '@aztec/foundation/fields';
-import { mockTx } from '@aztec/stdlib/testing';
+import { BlockProposal } from '@aztec/stdlib/p2p';
+import { makeBlockProposal, makeHeader, mockTx } from '@aztec/stdlib/testing';
 import { TxArray, TxHash, TxHashArray } from '@aztec/stdlib/tx';
 
 import { describe, expect, it } from '@jest/globals';
@@ -8,6 +10,15 @@ import { BitVector } from './bitvector.js';
 import { BlockTxsRequest, BlockTxsResponse } from './block_txs_reqresp.js';
 
 describe('BlockTxRequest', () => {
+  const createBlockProposal = (txHashes: TxHash[]): BlockProposal => {
+    return makeBlockProposal({
+      signer: Secp256k1Signer.random(),
+      header: makeHeader(1, 5),
+      archive: Fr.random(),
+      txHashes,
+    });
+  };
+
   it('should serialize and deserialize correctly', () => {
     const blockHash = Fr.random();
     const missing = new TxHashArray(...Array.from({ length: 4 }, () => TxHash.random()));
@@ -34,6 +45,96 @@ describe('BlockTxRequest', () => {
 
     expect(deserialized.blockHash).toEqual(blockHash);
     expect(deserialized.txIndices.getTrueIndices()).toEqual([]);
+  });
+
+  it('should create request with full tx hashes when includeFullTxHashes=true', () => {
+    const allTxHashes = Array.from({ length: 5 }, () => TxHash.random());
+    const blockProposal = createBlockProposal(allTxHashes);
+    const missingHashes = [allTxHashes[1], allTxHashes[3]];
+
+    const request = BlockTxsRequest.fromBlockProposalAndMissingTxs(blockProposal, missingHashes, true);
+
+    expect(request).toBeDefined();
+    expect(request!.blockHash).toEqual(blockProposal.archive);
+    expect(request!.txHashes.length).toBe(2);
+    expect(request!.txHashes).toEqual(new TxHashArray(...missingHashes));
+    expect(request!.txIndices.getTrueIndices()).toEqual([1, 3]);
+    expect(request!.txIndices.getLength()).toBe(5);
+  });
+
+  it('should create request without tx hashes when includeFullTxHashes=false', () => {
+    const allTxHashes = Array.from({ length: 5 }, () => TxHash.random());
+    const blockProposal = createBlockProposal(allTxHashes);
+    const missingHashes = [allTxHashes[0], allTxHashes[2], allTxHashes[4]];
+
+    const request = BlockTxsRequest.fromBlockProposalAndMissingTxs(blockProposal, missingHashes, false);
+
+    expect(request).toBeDefined();
+    expect(request!.blockHash).toEqual(blockProposal.archive);
+    expect(request!.txHashes.length).toBe(0);
+    expect(request!.txIndices.getTrueIndices()).toEqual([0, 2, 4]);
+    expect(request!.txIndices.getLength()).toBe(5);
+  });
+
+  it('should create request without tx hashes when includeFullTxHashes is not provided', () => {
+    const allTxHashes = Array.from({ length: 3 }, () => TxHash.random());
+    const blockProposal = createBlockProposal(allTxHashes);
+    const missingHashes = [allTxHashes[1]];
+
+    const request = BlockTxsRequest.fromBlockProposalAndMissingTxs(blockProposal, missingHashes);
+
+    expect(request).toBeDefined();
+    expect(request!.blockHash).toEqual(blockProposal.archive);
+    expect(request!.txHashes.length).toBe(0);
+    expect(request!.txIndices.getTrueIndices()).toEqual([1]);
+  });
+
+  it('should return undefined when no missing txs are provided', () => {
+    const allTxHashes = Array.from({ length: 3 }, () => TxHash.random());
+    const blockProposal = createBlockProposal(allTxHashes);
+
+    const request = BlockTxsRequest.fromBlockProposalAndMissingTxs(blockProposal, [], true);
+    expect(request).toBeUndefined();
+
+    const requestDefault = BlockTxsRequest.fromBlockProposalAndMissingTxs(blockProposal, []);
+    expect(requestDefault).toBeUndefined();
+  });
+
+  it('should return undefined when missing tx hashes do not match proposal hashes', () => {
+    const allTxHashes = Array.from({ length: 3 }, () => TxHash.random());
+    const blockProposal = createBlockProposal(allTxHashes);
+    const nonMatchingHashes = Array.from({ length: 2 }, () => TxHash.random());
+
+    const request = BlockTxsRequest.fromBlockProposalAndMissingTxs(blockProposal, nonMatchingHashes, true);
+    expect(request).toBeUndefined();
+  });
+
+  it('should serialize and deserialize correctly with full tx hashes', () => {
+    const allTxHashes = Array.from({ length: 4 }, () => TxHash.random());
+    const blockProposal = createBlockProposal(allTxHashes);
+    const missingHashes = [allTxHashes[0], allTxHashes[3]];
+
+    const original = BlockTxsRequest.fromBlockProposalAndMissingTxs(blockProposal, missingHashes, true)!;
+    const buffer = original.toBuffer();
+    const deserialized = BlockTxsRequest.fromBuffer(buffer);
+
+    expect(deserialized.blockHash).toEqual(original.blockHash);
+    expect(deserialized.txHashes).toEqual(original.txHashes);
+    expect(deserialized.txIndices.getTrueIndices()).toEqual(original.txIndices.getTrueIndices());
+  });
+
+  it('should serialize and deserialize correctly without tx hashes', () => {
+    const allTxHashes = Array.from({ length: 4 }, () => TxHash.random());
+    const blockProposal = createBlockProposal(allTxHashes);
+    const missingHashes = [allTxHashes[1], allTxHashes[2]];
+
+    const original = BlockTxsRequest.fromBlockProposalAndMissingTxs(blockProposal, missingHashes, false)!;
+    const buffer = original.toBuffer();
+    const deserialized = BlockTxsRequest.fromBuffer(buffer);
+
+    expect(deserialized.blockHash).toEqual(original.blockHash);
+    expect(deserialized.txHashes.length).toBe(0);
+    expect(deserialized.txIndices.getTrueIndices()).toEqual(original.txIndices.getTrueIndices());
   });
 });
 

--- a/yarn-project/p2p/src/services/reqresp/protocols/block_txs/block_txs_handler.ts
+++ b/yarn-project/p2p/src/services/reqresp/protocols/block_txs/block_txs_handler.ts
@@ -1,3 +1,4 @@
+import { Fr } from '@aztec/foundation/fields';
 import { TxArray } from '@aztec/stdlib/tx';
 
 import type { PeerId } from '@libp2p/interface';
@@ -32,6 +33,20 @@ export function reqRespBlockTxsHandler(attestationPool: AttestationPool, txPool:
 
     const blockProposal = await attestationPool.getBlockProposal(request.blockHash.toString());
 
+    let requestedTxsHashes;
+    if (request.txHashes.length > 0) {
+      requestedTxsHashes = request.txHashes;
+    }
+
+    // This is scenario in which we don't have this block proposal the peer is requesting from us
+    // But peer has sent requested tx hashes, so we can send them the transactions
+    if (!blockProposal && requestedTxsHashes !== undefined) {
+      const responseTxs = (await txPool.getTxsByHash(requestedTxsHashes)).filter(tx => !!tx);
+      const response = new BlockTxsResponse(Fr.zero(), new TxArray(...responseTxs), BitVector.init(0, []));
+      return response.toBuffer();
+    }
+
+    // If don't have this block proposal and peer has not sent requested tx hashes
     if (!blockProposal) {
       throw new ReqRespStatusError(ReqRespStatus.NOT_FOUND);
     }
@@ -42,10 +57,9 @@ export function reqRespBlockTxsHandler(attestationPool: AttestationPool, txPool:
     const responseBitVector = BitVector.init(blockProposal.txHashes.length, availableIndices);
 
     const requestedIndices = new Set(request.txIndices.getTrueIndices());
-    const requestedTxsHashes = blockProposal.txHashes.filter((_, idx) => requestedIndices.has(idx));
+    requestedTxsHashes = blockProposal.txHashes.filter((_, idx) => requestedIndices.has(idx));
 
     const responseTxs = (await txPool.getTxsByHash(requestedTxsHashes)).filter(tx => !!tx);
-
     const response = new BlockTxsResponse(request.blockHash, new TxArray(...responseTxs), responseBitVector);
 
     return response.toBuffer();

--- a/yarn-project/p2p/src/services/reqresp/protocols/block_txs/block_txs_reqresp.ts
+++ b/yarn-project/p2p/src/services/reqresp/protocols/block_txs/block_txs_reqresp.ts
@@ -1,7 +1,7 @@
 import { Fr } from '@aztec/foundation/fields';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 import type { BlockProposal } from '@aztec/stdlib/p2p';
-import { TxArray, TxHash } from '@aztec/stdlib/tx';
+import { TxArray, TxHash, TxHashArray } from '@aztec/stdlib/tx';
 
 import { BitVector } from './bitvector.js';
 
@@ -10,9 +10,14 @@ import { BitVector } from './bitvector.js';
  */
 export class BlockTxsRequest {
   constructor(
-    readonly blockHash: Fr, // 32 byte hash of the proposed block header
+    // 32 byte hash of the proposed block header
+    readonly blockHash: Fr,
+    // Hashes of txs we are requesting
+    readonly txHashes: TxHashArray,
     // BitVector indicating which txs from the proposal we are requesting
     // 1 means we want the tx, 0 means we don't
+    // If we know peer has the Block Proposal then we can use this BitVector
+    // Otherwise we can use this optimization
     readonly txIndices: BitVector,
   ) {}
 
@@ -38,13 +43,9 @@ export class BlockTxsRequest {
       .map((hash, idx) => (missingHashesSet.has(hash.toString()) ? idx : -1))
       .filter(i => i != -1);
 
-    if (missingIndices.length === 0) {
-      return undefined; // No indices found for missing tx hashes
-    }
-
     const requestBitVector = BitVector.init(blockProposal.txHashes.length, missingIndices);
 
-    return new BlockTxsRequest(blockProposal.archive, requestBitVector);
+    return new BlockTxsRequest(blockProposal.archive, new TxHashArray(...missingTxHashes), requestBitVector);
   }
 
   /**
@@ -55,9 +56,10 @@ export class BlockTxsRequest {
   static fromBuffer(buffer: Buffer | BufferReader): BlockTxsRequest {
     const reader = BufferReader.asReader(buffer);
     const blockHash = Fr.fromBuffer(reader);
+    const txHashes = TxHashArray.fromBuffer(reader);
     const txIndices = BitVector.fromBuffer(reader);
 
-    return new BlockTxsRequest(blockHash, txIndices);
+    return new BlockTxsRequest(blockHash, txHashes, txIndices);
   }
 
   /**
@@ -65,7 +67,7 @@ export class BlockTxsRequest {
    * @returns Buffer representation of the BlockTxRequest object
    */
   toBuffer(): Buffer {
-    return serializeToBuffer([this.blockHash, this.txIndices.toBuffer()]);
+    return serializeToBuffer([this.blockHash, this.txHashes.toBuffer(), this.txIndices.toBuffer()]);
   }
 }
 

--- a/yarn-project/p2p/src/services/reqresp/protocols/block_txs/block_txs_reqresp.ts
+++ b/yarn-project/p2p/src/services/reqresp/protocols/block_txs/block_txs_reqresp.ts
@@ -26,12 +26,14 @@ export class BlockTxsRequest {
    *
    * @param: blockProposal - The block proposal for which we are making request
    * @param: missingTxHashes - Tx hashes from the proposal we are missing
+   * @param: includeFullTxHashes - Whether to include full list of missing tx hashes in the request or just Bitvector indices
    *
    * @returns undefined if there were no missingTxHashes matching BlockProposal hashes, otherwise
    * returns new BlockTxsRequest*/
   static fromBlockProposalAndMissingTxs(
     blockProposal: BlockProposal,
     missingTxHashes: TxHash[],
+    includeFullTxHashes = false,
   ): BlockTxsRequest | undefined {
     if (missingTxHashes.length === 0) {
       return undefined; // No missing txs to request
@@ -39,13 +41,19 @@ export class BlockTxsRequest {
 
     const missingHashesSet = new Set(missingTxHashes.map(t => t.toString()));
 
+    // We cannot request txs that are not part of the block proposal
+    if (!missingHashesSet.isSubsetOf(new Set(blockProposal.txHashes.map(t => t.toString())))) {
+      return undefined;
+    }
+
     const missingIndices = blockProposal.txHashes
       .map((hash, idx) => (missingHashesSet.has(hash.toString()) ? idx : -1))
       .filter(i => i != -1);
 
     const requestBitVector = BitVector.init(blockProposal.txHashes.length, missingIndices);
+    const hashes = includeFullTxHashes ? new TxHashArray(...missingTxHashes) : new TxHashArray();
 
-    return new BlockTxsRequest(blockProposal.archive, new TxHashArray(...missingTxHashes), requestBitVector);
+    return new BlockTxsRequest(blockProposal.archive, hashes, requestBitVector);
   }
 
   /**


### PR DESCRIPTION
There is a solid chance that the peers we are requesting transactions from won't have the block proposal at the time of request. 
This is why we should make it optional to include the full tx hashes when sending block txs requests.
The idea is that so-called "dumb peers" include full hashes and "smart peers" only indices encoded in BitVector